### PR TITLE
Fix Saturday wine discount rules to include compound tags

### DIFF
--- a/snippets/daily-discount-label.liquid
+++ b/snippets/daily-discount-label.liquid
@@ -29,7 +29,7 @@ Behavior:
       {%- assign _discount_rules = 'CARNES,CARNE,CERDO:10|FRUVER:25' -%}
     {%- when 'Saturday' -%}
       {%- assign _day_translation = 'SÁBADO' -%}
-      {%- assign _discount_rules = 'VINO,VINOS:30' -%}
+      {%- assign _discount_rules = 'VINO,VINOS,BEBIDAS ALCOHOLICAS VINOS:30' -%}
     {%- else -%}
       {%- assign _discount_rules = '' -%}
   {%- endcase -%}


### PR DESCRIPTION
- Added 'BEBIDAS ALCOHOLICAS VINOS' to Saturday discount rules
- Now covers both exact 'VINOS' tags and compound wine tags
- Fixes red label not appearing for products like champagne-laurent-perrier
- Maintains compatibility with products that have exact 'VINOS' tag