### PR TITLE
Sync main -> staging (deploy PDP custom fields to staging)

### DIFF
--- a/.github/workflows/sync-staging.yml
+++ b/.github/workflows/sync-staging.yml
@@ -1,0 +1,35 @@
+name: Sync staging with main
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-staging
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Fast-forward staging to main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Push main -> staging (fast-forward)
+        run: |
+          git fetch origin
+          # Mirror main to staging. Use --force-with-lease to keep staging strictly synced while avoiding clobbering
+          # unexpected remote updates.
+          git push --force-with-lease origin HEAD:refs/heads/staging

--- a/snippets/cart.liquid
+++ b/snippets/cart.liquid
@@ -77,6 +77,25 @@
                               <p class="mb-0">{{ item.variant.title }}</p>
                             {%- endunless -%}
                           </div>
+                          {%- if item.properties and item.properties.size > 0 -%}
+                            <div class="mt-5">
+                              {%- for property in item.properties -%}
+                                {%- assign property_first_char = property.first | slice: 0 -%}
+                                {%- if property.last != blank and property_first_char != '_' -%}
+                                  <div class="product-option">
+                                    <dt>{{ property.first }}:</dt>
+                                    <dd>
+                                      {%- if property.last contains '/uploads/' -%}
+                                        <a href="{{ property.last }}" class="link" target="_blank">{{ property.last | split: '/' | last }}</a>
+                                      {%- else -%}
+                                        {{ property.last }}
+                                      {%- endif -%}
+                                    </dd>
+                                  </div>
+                                {%- endif -%}
+                              {%- endfor -%}
+                            </div>
+                          {%- endif -%}
                         </div>
                         <div class="col-sm-7 col-lg-8 col-xl-6">
                           <div class="row align-items-center">

--- a/snippets/pdp-custom-fields.liquid
+++ b/snippets/pdp-custom-fields.liquid
@@ -1,0 +1,78 @@
+{%- comment -%}
+  Renders PDP custom fields (select + text) as line item properties.
+  Visibility is controlled by shop metafield `custom.pdp_custom_fields_config` (JSON), example:
+  {
+    "enabled": true,
+    "visibility": { "by": "tags", "values": ["personalizable", "regalo"] },
+    "select": { "label": "Categoría", "required": true, "options": ["Cumpleaños","Aniversario","Felicitación"], "placeholder": "Seleccione una opción" },
+    "text": { "label": "Notas", "placeholder": "Instrucciones para el pedido...", "required": false, "maxlength": 200 }
+  }
+
+  Expected context:
+  - product
+  - product_form_id
+{%- endcomment -%}
+
+{%- assign _meta = shop.metafields.custom.pdp_custom_fields_config -%}
+{%- assign _cfg = blank -%}
+{%- if _meta != blank -%}
+  {%- assign _cfg = _meta.value -%}
+  {%- if _cfg == blank -%}{%- assign _cfg = _meta | parse_json -%}{%- endif -%}
+{%- endif -%}
+
+{%- assign _enabled = false -%}
+{%- if _cfg and _cfg.enabled == true -%}
+  {%- assign _enabled = true -%}
+{%- endif -%}
+
+{%- assign _visible = false -%}
+{%- assign _vis = _cfg.visibility -%}
+{%- if _vis and _vis.by == 'tags' and _vis.values -%}
+  {%- assign _tags_join = product.tags | join: '|' -%}
+  {%- assign _tags_str = '|' | append: _tags_join | append: '|' | downcase -%}
+  {%- for t in _vis.values -%}
+    {%- assign _t = t | downcase -%}
+    {%- assign _needle = '|' | append: _t | append: '|' -%}
+    {%- if _tags_str contains _needle -%}
+      {%- assign _visible = true -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- else -%}
+  {%- assign _visible = true -%}
+{%- endif -%}
+
+{%- assign _sel = _cfg.select -%}
+{%- assign _txt = _cfg.text -%}
+
+{%- assign _sel_label = _sel.label | default: 'Categoría' -%}
+{%- assign _sel_required = false -%}
+{%- if _sel and _sel.required == true -%}{%- assign _sel_required = true -%}{%- endif -%}
+{%- assign _sel_placeholder = _sel.placeholder | default: 'Seleccione una opción' -%}
+
+{%- assign _txt_label = _txt.label | default: 'Notas' -%}
+{%- assign _txt_required = false -%}
+{%- if _txt and _txt.required == true -%}{%- assign _txt_required = true -%}{%- endif -%}
+{%- assign _txt_placeholder = _txt.placeholder | default: 'Instrucciones para el pedido…' -%}
+{%- assign _txt_maxlen = 200 -%}
+{%- if _txt and _txt.maxlength -%}
+  {%- assign _txt_maxlen = _txt.maxlength | plus: 0 -%}
+{%- endif -%}
+
+{%- if _enabled and _visible -%}
+  <div class="product-page-info__field product-page-info__custom-fields mb-20">
+    {%- if _sel and _sel.options and _sel.options.size > 0 -%}
+      {%- assign _sel_id = 'pdp-select-' | append: section.id -%}
+      <label for="{{ _sel_id }}" class="mb-6">{{ _sel_label }}</label>
+      <select id="{{ _sel_id }}" name="properties[{{ _sel_label }}]" form="{{ product_form_id }}" class="mb-10"{% if _sel_required %} required{% endif %}>
+        <option value="" disabled selected>{{ _sel_placeholder }}</option>
+        {%- for opt in _sel.options -%}
+          <option value="{{ opt | strip }}">{{ opt }}</option>
+        {%- endfor -%}
+      </select>
+    {%- endif -%}
+
+    {%- assign _txt_id = 'pdp-text-' | append: section.id -%}
+    <label for="{{ _txt_id }}" class="mb-6">{{ _txt_label }}</label>
+    <textarea id="{{ _txt_id }}" name="properties[{{ _txt_label }}]" form="{{ product_form_id }}" placeholder="{{ _txt_placeholder }}" maxlength="{{ _txt_maxlen }}" class="mb-0"{% if _txt_required %} required{% endif %}></textarea>
+  </div>
+{%- endif -%}

--- a/snippets/product-page-get-info.liquid
+++ b/snippets/product-page-get-info.liquid
@@ -324,6 +324,7 @@
                     {% render 'product-get-quantity' with quantity_show_title: true quantity_connect: quantity_connect, product_form_id: product_form_id %}
                 </div>
             {%- endif -%}
+            {% render 'pdp-custom-fields', product: product, product_form_id: product_form_id %}
             {%- assign has_selling_plan = false -%}
             {% capture selling_plan_html %}
                 {% for variant in product.variants %}


### PR DESCRIPTION
Mantiene staging sincronizado con main para pruebas.\nIncluye: PDP campos informativos (select + notas) + render debajo de cantidad + propiedades en carrito.\n\nSi esta rama tiene protecciones que exigen PR, este PR las cumple. Tras el merge, staging quedará en el último commit de main.