### PR TITLE
fix: sidebar menu desliza desde la izquierda

### DIFF
--- a/snippets/sidebar-menu.liquid
+++ b/snippets/sidebar-menu.liquid
@@ -175,12 +175,12 @@
 .sidebar-menu {
   position: fixed;
   top: 0;
-  right: 0;
+  left: 0;
   width: 100%;
   max-width: 380px;
   height: 100%;
   background: #fff;
-  transform: translateX(100%);
+  transform: translateX(-100%);
   transition: transform 0.3s ease;
   z-index: 9999;
   display: flex;


### PR DESCRIPTION
Cambia el sidebar menu para que se deslice desde la izquierda en lugar de la derecha:\n- right: 0 → left: 0\n- transform: translateX(100%) → translateX(-100%)