### PR TITLE
feat: setting para menú mobile independiente

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -2279,6 +2279,12 @@
             "default": "main-menu"
         },
         {
+            "type": "link_list",
+            "id": "menu_mobile",
+            "label": "Menú Mobile (opcional)",
+            "info": "Si se selecciona, se mostrará este menú en mobile en lugar del menú principal. Si se deja vacío, se usa el menú principal."
+        },
+        {
             "type": "checkbox",
             "id": "show_menu_arrows",
             "label": "t:sections.header.settings.show_menu_arrows.label",

--- a/snippets/header-get-menu.liquid
+++ b/snippets/header-get-menu.liquid
@@ -1,8 +1,10 @@
-{%- if section.settings.menu != blank -%}
-    <nav class="menu {% if is_main_menu %}menu--main{% else %}menu--secondary{% endif %} js-menu js-position" data-js-position-name="menu">
+{%- if menu_handle != blank or section.settings.menu != blank -%}
+    {%- assign current_menu_handle = menu_handle | default: section.settings.menu -%}
+    {%- assign current_menu = linklists[current_menu_handle] -%}
+    <nav class="menu {% if is_main_menu %}menu--main{% else %}menu--secondary{% endif %} js-menu{% if use_position != false %} js-position" data-js-position-name="menu{% endif %}">
         <div class="menu__panel{% if header_menu_list_on_a_par %} menu__panel--on-a-par{% endif %} menu__list menu__level-01 d-flex flex-column flex-lg-row flex-lg-wrap{% if centered %} justify-content-lg-center{% endif %}">
             <div class="menu__curtain d-none position-lg-absolute"></div>
-            {%- assign menu = linklists[section.settings.menu] -%}
+            {%- assign menu = current_menu -%}
             {%- assign megamenu_index = 0 -%}
             {%- for link in menu.links -%}
                 {%- capture childrens -%}

--- a/snippets/popup-navigation.liquid
+++ b/snippets/popup-navigation.liquid
@@ -72,7 +72,13 @@
       
     </div>
     <div class="popup-navigation__menu d-lg-none{% if settings.search_show %} pt-25{% endif %} pb-25 px-10" data-js-menu-mobile>
-        <div class="container" data-js-position-mobile="menu"></div>
+        {%- if section.settings.menu_mobile != blank -%}
+            <div class="container">
+                {% include 'header-get-menu' with menu_handle: section.settings.menu_mobile, use_position: false, is_main_menu: true %}
+            </div>
+        {%- else -%}
+            <div class="container" data-js-position-mobile="menu"></div>
+        {%- endif -%}
       <br>
       {%- assign registro_show = section.settings.show_registro_link -%}
       {%- if registro_show -%}


### PR DESCRIPTION
Permite asignar un menú de Shopify diferente para mobile.

**Cambios:**
- header.liquid: nuevo setting `menu_mobile` (link_list)
- header-get-menu.liquid: acepta `menu_handle` y `use_position` params
- popup-navigation.liquid: renderiza menú mobile directamente si `menu_mobile` está configurado

**Uso:** En Theme Settings > Header > seleccionar menú en 'Menú Mobile'. Si se deja vacío, usa el menú principal.