### PR TITLE
feat: landing page de vinos

### DIFF
--- a/sections/wine-landing-crianza.liquid
+++ b/sections/wine-landing-crianza.liquid
@@ -1,0 +1,269 @@
+{%- style -%}
+  .wine-crianza {
+    padding: 80px 0;
+    background: {{ section.settings.bg_color | default: '#1a0a0a' }};
+    color: #fff;
+    overflow: hidden;
+  }
+  .wine-crianza__inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+  }
+  .wine-crianza__header {
+    text-align: center;
+    margin-bottom: 50px;
+  }
+  .wine-crianza__label {
+    font-size: 12px;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: {{ section.settings.accent_color | default: '#c9a96e' }};
+    margin-bottom: 12px;
+  }
+  .wine-crianza__heading {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    font-size: 38px;
+    font-weight: 400;
+    margin: 0;
+  }
+  .wine-crianza__timeline {
+    display: flex;
+    gap: 0;
+    position: relative;
+  }
+  .wine-crianza__timeline::before {
+    content: '';
+    position: absolute;
+    top: 60px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, {{ section.settings.accent_color | default: '#c9a96e' }}, transparent);
+  }
+  .wine-crianza__item {
+    flex: 1;
+    text-align: center;
+    padding: 0 16px;
+    position: relative;
+  }
+  .wine-crianza__dot {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: {{ section.settings.accent_color | default: '#c9a96e' }};
+    margin: 52px auto 24px;
+    position: relative;
+    z-index: 1;
+    box-shadow: 0 0 0 4px rgba(201,169,110,0.3);
+  }
+  .wine-crianza__years {
+    font-family: 'Georgia', serif;
+    font-size: 32px;
+    color: {{ section.settings.accent_color | default: '#c9a96e' }};
+    margin-bottom: 8px;
+  }
+  .wine-crianza__name {
+    font-family: 'Georgia', serif;
+    font-size: 20px;
+    margin: 0 0 12px;
+    font-weight: 400;
+  }
+  .wine-crianza__desc {
+    font-size: 14px;
+    line-height: 1.65;
+    color: rgba(255,255,255,0.65);
+  }
+  .wine-crianza__icon {
+    width: 48px;
+    height: 48px;
+    margin: 0 auto;
+  }
+  .wine-crianza__icon svg {
+    width: 48px;
+    height: 48px;
+    stroke: {{ section.settings.accent_color | default: '#c9a96e' }};
+  }
+  @media (max-width: 767px) {
+    .wine-crianza { padding: 50px 0; }
+    .wine-crianza__heading { font-size: 28px; }
+    .wine-crianza__timeline {
+      flex-direction: column;
+      gap: 32px;
+    }
+    .wine-crianza__timeline::before {
+      top: 0;
+      bottom: 0;
+      left: 50%;
+      right: auto;
+      width: 2px;
+      height: 100%;
+    }
+    .wine-crianza__dot {
+      margin: 0 auto 16px;
+    }
+    .wine-crianza__icon {
+      margin-bottom: 8px;
+    }
+  }
+{%- endstyle -%}
+
+<section class="wine-crianza">
+  <div class="wine-crianza__inner">
+    <div class="wine-crianza__header">
+      {%- if section.settings.label != blank -%}
+        <p class="wine-crianza__label">{{ section.settings.label }}</p>
+      {%- endif -%}
+      {%- if section.settings.heading != blank -%}
+        <h2 class="wine-crianza__heading">{{ section.settings.heading }}</h2>
+      {%- endif -%}
+    </div>
+
+    <div class="wine-crianza__timeline">
+      {%- for block in section.blocks -%}
+        <div class="wine-crianza__item" {{ block.shopify_attributes }}>
+          <div class="wine-crianza__icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round">
+              {%- case block.settings.icon -%}
+                {%- when 'grape' -%}
+                  <circle cx="9" cy="9" r="3"/><circle cx="15" cy="9" r="3"/><circle cx="12" cy="14" r="3"/><path d="M12 17v4"/>
+                {%- when 'barrel' -%}
+                  <rect x="4" y="4" width="16" height="16" rx="3"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="12" y1="4" x2="12" y2="20"/>
+                {%- when 'bottle' -%}
+                  <path d="M10 2h4v4l2 4v10a2 2 0 01-2 2h-4a2 2 0 01-2-2V10l2-4V2z"/>
+                {%- when 'glass' -%}
+                  <path d="M8 2h8l-1 8a5 5 0 01-3 4.5V20h4v2H8v-2h4v-5.5A5 5 0 019 10L8 2z"/>
+                {%- else -%}
+                  <circle cx="12" cy="12" r="8"/><path d="M12 8v4l3 3"/>
+              {%- endcase -%}
+            </svg>
+          </div>
+          <div class="wine-crianza__dot"></div>
+          {%- if block.settings.years != blank -%}
+            <div class="wine-crianza__years">{{ block.settings.years }}</div>
+          {%- endif -%}
+          {%- if block.settings.name != blank -%}
+            <h3 class="wine-crianza__name">{{ block.settings.name }}</h3>
+          {%- endif -%}
+          {%- if block.settings.description != blank -%}
+            <p class="wine-crianza__desc">{{ block.settings.description }}</p>
+          {%- endif -%}
+        </div>
+      {%- endfor -%}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Wine Landing - Crianza",
+  "tag": "section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "label",
+      "label": "Etiqueta",
+      "default": "Proceso de Envejecimiento"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Titulo",
+      "default": "Niveles de Crianza"
+    },
+    {
+      "type": "color",
+      "id": "bg_color",
+      "label": "Color de fondo",
+      "default": "#1a0a0a"
+    },
+    {
+      "type": "color",
+      "id": "accent_color",
+      "label": "Color de acento",
+      "default": "#c9a96e"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "level",
+      "name": "Nivel de crianza",
+      "settings": [
+        {
+          "type": "select",
+          "id": "icon",
+          "label": "Icono",
+          "options": [
+            { "value": "grape", "label": "Uva" },
+            { "value": "barrel", "label": "Barrica" },
+            { "value": "bottle", "label": "Botella" },
+            { "value": "glass", "label": "Copa" },
+            { "value": "clock", "label": "Reloj" }
+          ],
+          "default": "barrel"
+        },
+        {
+          "type": "text",
+          "id": "years",
+          "label": "Tiempo",
+          "default": "24 meses"
+        },
+        {
+          "type": "text",
+          "id": "name",
+          "label": "Nombre",
+          "default": "Crianza"
+        },
+        {
+          "type": "textarea",
+          "id": "description",
+          "label": "Descripcion"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Wine Landing - Crianza",
+      "blocks": [
+        {
+          "type": "level",
+          "settings": {
+            "icon": "grape",
+            "years": "0-12 meses",
+            "name": "Joven",
+            "description": "Vino del anio que destaca por su frescura y frutosidad. Sin paso por barrica."
+          }
+        },
+        {
+          "type": "level",
+          "settings": {
+            "icon": "barrel",
+            "years": "24 meses",
+            "name": "Crianza",
+            "description": "Envejecimiento en barrica de roble. El vino evoluciona adquiriendo complejidad y matices."
+          }
+        },
+        {
+          "type": "level",
+          "settings": {
+            "icon": "bottle",
+            "years": "36 meses",
+            "name": "Reserva",
+            "description": "Minimo 12 meses en barrica de roble mas reposo en botella. Mayor estructura y elegancia."
+          }
+        },
+        {
+          "type": "level",
+          "settings": {
+            "icon": "glass",
+            "years": "60 meses",
+            "name": "Gran Reserva",
+            "description": "5 anios de crianza total con 18-24 meses en barrica. Solo de aniadas excelentes."
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/wine-landing-cta.liquid
+++ b/sections/wine-landing-cta.liquid
@@ -1,0 +1,182 @@
+{%- style -%}
+  .wine-cta {
+    position: relative;
+    padding: 100px 20px;
+    text-align: center;
+    overflow: hidden;
+    background: {{ section.settings.bg_color | default: '#2d0a1a' }};
+  }
+  .wine-cta__bg {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+  .wine-cta__bg img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.25;
+  }
+  .wine-cta__content {
+    position: relative;
+    z-index: 2;
+    max-width: 700px;
+    margin: 0 auto;
+  }
+  .wine-cta__icon {
+    width: 60px;
+    height: 60px;
+    margin: 0 auto 24px;
+  }
+  .wine-cta__icon svg {
+    width: 100%;
+    height: 100%;
+    stroke: {{ section.settings.accent_color | default: '#c9a96e' }};
+  }
+  .wine-cta__heading {
+    font-family: 'Georgia', serif;
+    font-size: 36px;
+    font-weight: 400;
+    color: #fff;
+    margin: 0 0 16px;
+    line-height: 1.3;
+  }
+  .wine-cta__text {
+    font-size: 17px;
+    color: rgba(255,255,255,0.75);
+    line-height: 1.7;
+    margin: 0 0 32px;
+  }
+  .wine-cta__buttons {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .wine-cta__btn {
+    display: inline-block;
+    padding: 14px 36px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: all 0.3s ease;
+  }
+  .wine-cta__btn--primary {
+    background: {{ section.settings.accent_color | default: '#c9a96e' }};
+    color: #1a0a0a;
+  }
+  .wine-cta__btn--primary:hover {
+    background: #fff;
+  }
+  .wine-cta__btn--secondary {
+    background: transparent;
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.4);
+  }
+  .wine-cta__btn--secondary:hover {
+    border-color: #fff;
+    background: rgba(255,255,255,0.1);
+  }
+  @media (max-width: 767px) {
+    .wine-cta { padding: 60px 20px; }
+    .wine-cta__heading { font-size: 26px; }
+    .wine-cta__buttons { flex-direction: column; align-items: center; }
+  }
+{%- endstyle -%}
+
+<section class="wine-cta">
+  {%- if section.settings.bg_image != blank -%}
+    <div class="wine-cta__bg">
+      {{ section.settings.bg_image | image_url: width: 1920 | image_tag: loading: 'lazy', sizes: '100vw' }}
+    </div>
+  {%- endif -%}
+  <div class="wine-cta__content">
+    <div class="wine-cta__icon">
+      <svg viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round">
+        <path d="M8 2h8l-1 8a5 5 0 01-3 4.5V20h4v2H8v-2h4v-5.5A5 5 0 019 10L8 2z"/>
+      </svg>
+    </div>
+    {%- if section.settings.heading != blank -%}
+      <h2 class="wine-cta__heading">{{ section.settings.heading }}</h2>
+    {%- endif -%}
+    {%- if section.settings.text != blank -%}
+      <p class="wine-cta__text">{{ section.settings.text }}</p>
+    {%- endif -%}
+    <div class="wine-cta__buttons">
+      {%- if section.settings.btn1_text != blank -%}
+        <a href="{{ section.settings.btn1_url }}" class="wine-cta__btn wine-cta__btn--primary">{{ section.settings.btn1_text }}</a>
+      {%- endif -%}
+      {%- if section.settings.btn2_text != blank -%}
+        <a href="{{ section.settings.btn2_url }}" class="wine-cta__btn wine-cta__btn--secondary">{{ section.settings.btn2_text }}</a>
+      {%- endif -%}
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Wine Landing - CTA",
+  "tag": "section",
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "bg_image",
+      "label": "Imagen de fondo"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Titulo",
+      "default": "Encuentra tu vino perfecto"
+    },
+    {
+      "type": "textarea",
+      "id": "text",
+      "label": "Texto",
+      "default": "Explora nuestra seleccion completa y deja que cada copa cuente una historia."
+    },
+    {
+      "type": "text",
+      "id": "btn1_text",
+      "label": "Boton primario texto",
+      "default": "Ver Todos los Vinos"
+    },
+    {
+      "type": "url",
+      "id": "btn1_url",
+      "label": "Boton primario URL"
+    },
+    {
+      "type": "text",
+      "id": "btn2_text",
+      "label": "Boton secundario texto",
+      "default": "Ofertas Especiales"
+    },
+    {
+      "type": "url",
+      "id": "btn2_url",
+      "label": "Boton secundario URL"
+    },
+    {
+      "type": "color",
+      "id": "bg_color",
+      "label": "Color de fondo",
+      "default": "#2d0a1a"
+    },
+    {
+      "type": "color",
+      "id": "accent_color",
+      "label": "Color de acento",
+      "default": "#c9a96e"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Wine Landing - CTA"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/wine-landing-dictionary.liquid
+++ b/sections/wine-landing-dictionary.liquid
@@ -1,0 +1,242 @@
+{%- style -%}
+  .wine-dict {
+    padding: 80px 0;
+    background: {{ section.settings.bg_color | default: '#fff' }};
+  }
+  .wine-dict__inner {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 0 20px;
+  }
+  .wine-dict__header {
+    text-align: center;
+    margin-bottom: 50px;
+  }
+  .wine-dict__label {
+    font-size: 12px;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: {{ section.settings.accent_color | default: '#8b1a2b' }};
+    margin-bottom: 12px;
+  }
+  .wine-dict__heading {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    font-size: 38px;
+    font-weight: 400;
+    color: #1a0a0a;
+    margin: 0 0 12px;
+  }
+  .wine-dict__intro {
+    font-size: 16px;
+    color: #6b5e5e;
+    line-height: 1.6;
+  }
+  .wine-dict__search {
+    max-width: 500px;
+    margin: 0 auto 40px;
+    position: relative;
+  }
+  .wine-dict__search input {
+    width: 100%;
+    padding: 14px 20px 14px 48px;
+    border: 2px solid #e8e2dc;
+    border-radius: 50px;
+    font-size: 15px;
+    background: #faf8f5;
+    outline: none;
+    transition: border-color 0.3s;
+    box-sizing: border-box;
+  }
+  .wine-dict__search input:focus {
+    border-color: {{ section.settings.accent_color | default: '#8b1a2b' }};
+  }
+  .wine-dict__search svg {
+    position: absolute;
+    left: 18px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 18px;
+    height: 18px;
+    stroke: #a09890;
+  }
+  .wine-dict__columns {
+    column-count: 2;
+    column-gap: 40px;
+  }
+  .wine-dict__item {
+    break-inside: avoid;
+    margin-bottom: 20px;
+    padding: 20px 24px;
+    background: #faf8f5;
+    border-radius: 10px;
+    border-left: 3px solid {{ section.settings.accent_color | default: '#8b1a2b' }};
+    transition: opacity 0.3s, transform 0.3s;
+  }
+  .wine-dict__item.is-hidden {
+    display: none;
+  }
+  .wine-dict__term {
+    font-family: 'Georgia', serif;
+    font-size: 18px;
+    font-weight: 400;
+    color: #1a0a0a;
+    margin: 0 0 6px;
+  }
+  .wine-dict__def {
+    font-size: 14px;
+    line-height: 1.65;
+    color: #6b5e5e;
+    margin: 0;
+  }
+  .wine-dict__empty {
+    text-align: center;
+    padding: 40px;
+    color: #a09890;
+    font-size: 16px;
+    display: none;
+  }
+  .wine-dict__empty.is-visible {
+    display: block;
+  }
+  @media (max-width: 767px) {
+    .wine-dict { padding: 50px 0; }
+    .wine-dict__heading { font-size: 28px; }
+    .wine-dict__columns { column-count: 1; }
+  }
+{%- endstyle -%}
+
+<section class="wine-dict" id="wine-dictionary-{{ section.id }}">
+  <div class="wine-dict__inner">
+    <div class="wine-dict__header">
+      {%- if section.settings.label != blank -%}
+        <p class="wine-dict__label">{{ section.settings.label }}</p>
+      {%- endif -%}
+      {%- if section.settings.heading != blank -%}
+        <h2 class="wine-dict__heading">{{ section.settings.heading }}</h2>
+      {%- endif -%}
+      {%- if section.settings.intro != blank -%}
+        <p class="wine-dict__intro">{{ section.settings.intro }}</p>
+      {%- endif -%}
+    </div>
+
+    {%- if section.settings.show_search -%}
+      <div class="wine-dict__search">
+        <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+        <input type="text" placeholder="Buscar termino..." data-wine-dict-search="{{ section.id }}">
+      </div>
+    {%- endif -%}
+
+    <div class="wine-dict__columns" data-wine-dict-list="{{ section.id }}">
+      {%- for block in section.blocks -%}
+        <div class="wine-dict__item" data-wine-term="{{ block.settings.term | downcase }}" {{ block.shopify_attributes }}>
+          <h3 class="wine-dict__term">{{ block.settings.term }}</h3>
+          <p class="wine-dict__def">{{ block.settings.definition }}</p>
+        </div>
+      {%- endfor -%}
+    </div>
+    <p class="wine-dict__empty" data-wine-dict-empty="{{ section.id }}">No se encontraron terminos.</p>
+  </div>
+</section>
+
+<script>
+  (function() {
+    var sid = '{{ section.id }}';
+    var input = document.querySelector('[data-wine-dict-search="' + sid + '"]');
+    if (!input) return;
+    var items = document.querySelectorAll('[data-wine-dict-list="' + sid + '"] .wine-dict__item');
+    var empty = document.querySelector('[data-wine-dict-empty="' + sid + '"]');
+    input.addEventListener('input', function() {
+      var q = this.value.toLowerCase().trim();
+      var visible = 0;
+      items.forEach(function(item) {
+        var term = item.getAttribute('data-wine-term') || '';
+        var match = !q || term.indexOf(q) !== -1;
+        item.classList.toggle('is-hidden', !match);
+        if (match) visible++;
+      });
+      if (empty) empty.classList.toggle('is-visible', visible === 0);
+    });
+  })();
+</script>
+
+{% schema %}
+{
+  "name": "Wine Landing - Diccionario",
+  "tag": "section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "label",
+      "label": "Etiqueta",
+      "default": "Aprende Sobre Vinos"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Titulo",
+      "default": "Diccionario del Vino"
+    },
+    {
+      "type": "textarea",
+      "id": "intro",
+      "label": "Texto introductorio",
+      "default": "Domina el vocabulario del vino y sorprende en tu proxima cata."
+    },
+    {
+      "type": "checkbox",
+      "id": "show_search",
+      "label": "Mostrar buscador",
+      "default": true
+    },
+    {
+      "type": "color",
+      "id": "bg_color",
+      "label": "Color de fondo",
+      "default": "#ffffff"
+    },
+    {
+      "type": "color",
+      "id": "accent_color",
+      "label": "Color de acento",
+      "default": "#8b1a2b"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "term",
+      "name": "Termino",
+      "settings": [
+        {
+          "type": "text",
+          "id": "term",
+          "label": "Termino"
+        },
+        {
+          "type": "textarea",
+          "id": "definition",
+          "label": "Definicion"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Wine Landing - Diccionario",
+      "blocks": [
+        { "type": "term", "settings": { "term": "Acerbo", "definition": "Se dice del vino que es a la vez aspero, duro y acido." } },
+        { "type": "term", "settings": { "term": "Afinado", "definition": "Vino delicado y aromatico que recuerda el sabor y el olor del fruto. Caracteristica de vinos jovenes." } },
+        { "type": "term", "settings": { "term": "Amontillado", "definition": "Vino generoso de color ambar, aroma punzante y avellanado, suave y lleno al paladar, con 18 grados." } },
+        { "type": "term", "settings": { "term": "Complejo", "definition": "Vino que ofrece una amplia gama de sensaciones, armonia y equilibrio." } },
+        { "type": "term", "settings": { "term": "Cuerpo", "definition": "Caracteristica ligada al grado alcoholico y extracto seco. Un vino con cuerpo es estructurado, con fuerza y vinosidad." } },
+        { "type": "term", "settings": { "term": "Equilibrado", "definition": "Vino que presenta un conjunto armonioso de caracteres, sin que ninguno sobresalga sobre los demas." } },
+        { "type": "term", "settings": { "term": "Hollejo", "definition": "Piel de la uva que contiene taninos. Estos dan caracter al vino y permiten su conservacion." } },
+        { "type": "term", "settings": { "term": "Joven", "definition": "Vino del anio que destaca por su frescura y frutosidad." } },
+        { "type": "term", "settings": { "term": "Mosto", "definition": "Zumo de uva sin fermentar, compuesto por agua (80%), azucar (17%), vitaminas y minerales." } },
+        { "type": "term", "settings": { "term": "Seco", "definition": "Vino sin restos de azucar." } },
+        { "type": "term", "settings": { "term": "Tanico", "definition": "Vino que muestra en boca la astringencia de sus taninos." } },
+        { "type": "term", "settings": { "term": "Varietal", "definition": "Vino elaborado a partir de una unica variedad de uva." } }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/wine-landing-hero.liquid
+++ b/sections/wine-landing-hero.liquid
@@ -1,0 +1,191 @@
+{%- style -%}
+  .wine-hero {
+    position: relative;
+    min-height: 520px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    background: {{ section.settings.bg_color | default: '#1a0a0a' }};
+  }
+  .wine-hero__bg {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+  .wine-hero__bg img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: {{ section.settings.overlay_opacity | divided_by: 100.0 }};
+  }
+  .wine-hero__content {
+    position: relative;
+    z-index: 2;
+    text-align: center;
+    padding: 60px 20px;
+    max-width: 800px;
+  }
+  .wine-hero__badge {
+    display: inline-block;
+    font-size: 12px;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: {{ section.settings.accent_color | default: '#c9a96e' }};
+    border: 1px solid {{ section.settings.accent_color | default: '#c9a96e' }};
+    padding: 6px 20px;
+    border-radius: 30px;
+    margin-bottom: 20px;
+  }
+  .wine-hero__title {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    font-size: 52px;
+    font-weight: 400;
+    line-height: 1.15;
+    color: #fff;
+    margin: 0 0 16px;
+  }
+  .wine-hero__subtitle {
+    font-size: 18px;
+    line-height: 1.7;
+    color: rgba(255,255,255,0.8);
+    margin: 0 0 32px;
+    font-weight: 300;
+  }
+  .wine-hero__cta {
+    display: inline-block;
+    padding: 14px 40px;
+    background: {{ section.settings.accent_color | default: '#c9a96e' }};
+    color: #1a0a0a;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: all 0.3s ease;
+  }
+  .wine-hero__cta:hover {
+    background: #fff;
+    color: #1a0a0a;
+  }
+  .wine-hero__scroll {
+    position: absolute;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2;
+    animation: wineHeroBounce 2s infinite;
+  }
+  .wine-hero__scroll svg {
+    width: 24px;
+    height: 24px;
+    stroke: {{ section.settings.accent_color | default: '#c9a96e' }};
+  }
+  @keyframes wineHeroBounce {
+    0%, 100% { transform: translateX(-50%) translateY(0); }
+    50% { transform: translateX(-50%) translateY(8px); }
+  }
+  @media (max-width: 767px) {
+    .wine-hero { min-height: 420px; }
+    .wine-hero__title { font-size: 32px; }
+    .wine-hero__subtitle { font-size: 15px; }
+  }
+{%- endstyle -%}
+
+<section class="wine-hero">
+  <div class="wine-hero__bg">
+    {%- if section.settings.hero_image != blank -%}
+      {{ section.settings.hero_image | image_url: width: 1920 | image_tag: loading: 'eager', sizes: '100vw' }}
+    {%- else -%}
+      <div style="width:100%;height:100%;background:linear-gradient(135deg,#2d0a0a 0%,#4a1528 50%,#1a0a2e 100%)"></div>
+    {%- endif -%}
+  </div>
+  <div class="wine-hero__content">
+    {%- if section.settings.badge != blank -%}
+      <span class="wine-hero__badge">{{ section.settings.badge }}</span>
+    {%- endif -%}
+    {%- if section.settings.title != blank -%}
+      <h1 class="wine-hero__title">{{ section.settings.title }}</h1>
+    {%- endif -%}
+    {%- if section.settings.subtitle != blank -%}
+      <p class="wine-hero__subtitle">{{ section.settings.subtitle }}</p>
+    {%- endif -%}
+    {%- if section.settings.cta_text != blank -%}
+      <a href="{{ section.settings.cta_url }}" class="wine-hero__cta">{{ section.settings.cta_text }}</a>
+    {%- endif -%}
+  </div>
+  <div class="wine-hero__scroll">
+    <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12l7 7 7-7"/></svg>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Wine Landing - Hero",
+  "tag": "section",
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "hero_image",
+      "label": "Imagen de fondo"
+    },
+    {
+      "type": "text",
+      "id": "badge",
+      "label": "Badge superior",
+      "default": "Supermu Vinos"
+    },
+    {
+      "type": "text",
+      "id": "title",
+      "label": "Titulo",
+      "default": "El Arte del Vino"
+    },
+    {
+      "type": "textarea",
+      "id": "subtitle",
+      "label": "Subtitulo",
+      "default": "Descubre nuestra seleccion curada de vinos del mundo. Desde tintos con caracter hasta blancos refrescantes."
+    },
+    {
+      "type": "text",
+      "id": "cta_text",
+      "label": "Texto del boton",
+      "default": "Explorar Vinos"
+    },
+    {
+      "type": "url",
+      "id": "cta_url",
+      "label": "URL del boton"
+    },
+    {
+      "type": "color",
+      "id": "bg_color",
+      "label": "Color de fondo",
+      "default": "#1a0a0a"
+    },
+    {
+      "type": "color",
+      "id": "accent_color",
+      "label": "Color de acento",
+      "default": "#c9a96e"
+    },
+    {
+      "type": "range",
+      "id": "overlay_opacity",
+      "label": "Opacidad de imagen",
+      "min": 10,
+      "max": 100,
+      "step": 5,
+      "default": 40,
+      "unit": "%"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Wine Landing - Hero"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/wine-landing-types.liquid
+++ b/sections/wine-landing-types.liquid
@@ -1,0 +1,339 @@
+{%- style -%}
+  .wine-types {
+    padding: 80px 0;
+    background: {{ section.settings.bg_color | default: '#faf8f5' }};
+  }
+  .wine-types__header {
+    text-align: center;
+    max-width: 700px;
+    margin: 0 auto 50px;
+    padding: 0 20px;
+  }
+  .wine-types__label {
+    font-size: 12px;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: {{ section.settings.accent_color | default: '#8b1a2b' }};
+    margin-bottom: 12px;
+  }
+  .wine-types__heading {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    font-size: 38px;
+    font-weight: 400;
+    color: #1a0a0a;
+    margin: 0 0 12px;
+  }
+  .wine-types__intro {
+    font-size: 16px;
+    line-height: 1.7;
+    color: #6b5e5e;
+  }
+  .wine-types__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+  }
+  .wine-card {
+    background: #fff;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 20px rgba(0,0,0,0.06);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    display: flex;
+    flex-direction: column;
+  }
+  .wine-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 30px rgba(0,0,0,0.12);
+  }
+  .wine-card__image {
+    position: relative;
+    height: 220px;
+    overflow: hidden;
+  }
+  .wine-card__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s ease;
+  }
+  .wine-card:hover .wine-card__image img {
+    transform: scale(1.05);
+  }
+  .wine-card__color-bar {
+    height: 4px;
+    background: var(--wine-card-color, #8b1a2b);
+  }
+  .wine-card__body {
+    padding: 24px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+  .wine-card__tag {
+    display: inline-block;
+    font-size: 10px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--wine-card-color, #8b1a2b);
+    background: color-mix(in srgb, var(--wine-card-color, #8b1a2b) 10%, transparent);
+    padding: 4px 12px;
+    border-radius: 20px;
+    margin-bottom: 12px;
+    width: fit-content;
+  }
+  .wine-card__name {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    font-size: 22px;
+    font-weight: 400;
+    color: #1a0a0a;
+    margin: 0 0 10px;
+  }
+  .wine-card__desc {
+    font-size: 14px;
+    line-height: 1.65;
+    color: #6b5e5e;
+    flex: 1;
+  }
+  .wine-card__maridaje {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #f0ece8;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .wine-card__maridaje svg {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    margin-top: 2px;
+    stroke: var(--wine-card-color, #8b1a2b);
+  }
+  .wine-card__maridaje span {
+    font-size: 13px;
+    color: #8a7d7d;
+    line-height: 1.5;
+  }
+  .wine-card__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 16px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--wine-card-color, #8b1a2b);
+    text-decoration: none;
+    letter-spacing: 0.5px;
+    transition: gap 0.2s ease;
+  }
+  .wine-card__link:hover { gap: 10px; }
+  .wine-card__link svg {
+    width: 14px;
+    height: 14px;
+    stroke: currentColor;
+  }
+  @media (max-width: 991px) {
+    .wine-types__grid { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 600px) {
+    .wine-types { padding: 50px 0; }
+    .wine-types__heading { font-size: 28px; }
+    .wine-types__grid {
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+  }
+{%- endstyle -%}
+
+<section class="wine-types">
+  <div class="wine-types__header">
+    {%- if section.settings.label != blank -%}
+      <p class="wine-types__label">{{ section.settings.label }}</p>
+    {%- endif -%}
+    {%- if section.settings.heading != blank -%}
+      <h2 class="wine-types__heading">{{ section.settings.heading }}</h2>
+    {%- endif -%}
+    {%- if section.settings.intro != blank -%}
+      <p class="wine-types__intro">{{ section.settings.intro }}</p>
+    {%- endif -%}
+  </div>
+
+  <div class="wine-types__grid">
+    {%- for block in section.blocks -%}
+      <div class="wine-card" style="--wine-card-color: {{ block.settings.card_color | default: '#8b1a2b' }}" {{ block.shopify_attributes }}>
+        {%- if block.settings.image != blank -%}
+          <div class="wine-card__image">
+            {{ block.settings.image | image_url: width: 600 | image_tag: loading: 'lazy', sizes: '(max-width: 600px) 100vw, (max-width: 991px) 50vw, 33vw' }}
+          </div>
+        {%- endif -%}
+        <div class="wine-card__color-bar"></div>
+        <div class="wine-card__body">
+          {%- if block.settings.tag != blank -%}
+            <span class="wine-card__tag">{{ block.settings.tag }}</span>
+          {%- endif -%}
+          {%- if block.settings.name != blank -%}
+            <h3 class="wine-card__name">{{ block.settings.name }}</h3>
+          {%- endif -%}
+          {%- if block.settings.description != blank -%}
+            <p class="wine-card__desc">{{ block.settings.description }}</p>
+          {%- endif -%}
+          {%- if block.settings.maridaje != blank -%}
+            <div class="wine-card__maridaje">
+              <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round"><path d="M18 8h1a4 4 0 010 8h-1"/><path d="M2 8h16v9a4 4 0 01-4 4H6a4 4 0 01-4-4V8z"/><path d="M6 1v3M10 1v3M14 1v3"/></svg>
+              <span><strong>Maridaje:</strong> {{ block.settings.maridaje }}</span>
+            </div>
+          {%- endif -%}
+          {%- if block.settings.link_url != blank -%}
+            <a href="{{ block.settings.link_url }}" class="wine-card__link">
+              {{ block.settings.link_text | default: 'Ver coleccion' }}
+              <svg viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            </a>
+          {%- endif -%}
+        </div>
+      </div>
+    {%- endfor -%}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Wine Landing - Tipos",
+  "tag": "section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "label",
+      "label": "Etiqueta superior",
+      "default": "Nuestra Seleccion"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Titulo",
+      "default": "Tipos de Vino"
+    },
+    {
+      "type": "textarea",
+      "id": "intro",
+      "label": "Texto introductorio",
+      "default": "Cada tipo de vino tiene su propio caracter, historia y momento ideal para disfrutarlo."
+    },
+    {
+      "type": "color",
+      "id": "bg_color",
+      "label": "Color de fondo",
+      "default": "#faf8f5"
+    },
+    {
+      "type": "color",
+      "id": "accent_color",
+      "label": "Color de acento",
+      "default": "#8b1a2b"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "wine_type",
+      "name": "Tipo de vino",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Imagen"
+        },
+        {
+          "type": "text",
+          "id": "tag",
+          "label": "Etiqueta",
+          "default": "Tinto"
+        },
+        {
+          "type": "text",
+          "id": "name",
+          "label": "Nombre",
+          "default": "Vino Tinto"
+        },
+        {
+          "type": "textarea",
+          "id": "description",
+          "label": "Descripcion"
+        },
+        {
+          "type": "text",
+          "id": "maridaje",
+          "label": "Maridaje",
+          "info": "Ej: Carnes rojas, quesos curados"
+        },
+        {
+          "type": "color",
+          "id": "card_color",
+          "label": "Color de la tarjeta",
+          "default": "#8b1a2b"
+        },
+        {
+          "type": "url",
+          "id": "link_url",
+          "label": "URL del enlace"
+        },
+        {
+          "type": "text",
+          "id": "link_text",
+          "label": "Texto del enlace",
+          "default": "Ver coleccion"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Wine Landing - Tipos",
+      "blocks": [
+        {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Tinto",
+            "name": "Vino Tinto",
+            "description": "Elaborado a partir de uvas tintas, con maceración del jugo junto con los hollejos. Rico en taninos, con cuerpo y complejidad.",
+            "maridaje": "Carnes rojas, quesos curados, pastas con salsa",
+            "card_color": "#8b1a2b"
+          }
+        },
+        {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Blanco",
+            "name": "Vino Blanco",
+            "description": "Producido sin contacto con la piel de la uva. Color amarillo palido a dorado, perfil fresco, ligero y acido.",
+            "maridaje": "Pescados, mariscos, quesos suaves",
+            "card_color": "#c9a96e"
+          }
+        },
+        {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Rosado",
+            "name": "Vino Rosado",
+            "description": "Uvas tintas con contacto breve con hollejos. Fresco, ligero y afrutado, ideal para consumirse joven.",
+            "maridaje": "Comida mediterranea, mariscos, ensaladas",
+            "card_color": "#d4729a"
+          }
+        },
+        {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Espumoso",
+            "name": "Champan y Cava",
+            "description": "Vinos con gas carbonico de segunda fermentacion. Burbujas finas y sabores complejos para celebrar cada momento.",
+            "maridaje": "Aperitivos, mariscos, postres",
+            "card_color": "#a68b5b"
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/templates/page.wine-landing.json
+++ b/templates/page.wine-landing.json
@@ -1,0 +1,191 @@
+{
+  "sections": {
+    "wine_hero": {
+      "type": "wine-landing-hero",
+      "settings": {
+        "badge": "Supermu Vinos",
+        "title": "El Arte del Vino",
+        "subtitle": "Descubre nuestra seleccion curada de vinos del mundo. Desde tintos con caracter hasta blancos refrescantes y espumosos para celebrar.",
+        "cta_text": "Explorar Vinos",
+        "bg_color": "#1a0a0a",
+        "accent_color": "#c9a96e",
+        "overlay_opacity": 40
+      }
+    },
+    "wine_types": {
+      "type": "wine-landing-types",
+      "blocks": {
+        "tinto": {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Tinto",
+            "name": "Vino Tinto",
+            "description": "Elaborado a partir de uvas tintas con maceracion del jugo junto con los hollejos. Rico en taninos, con cuerpo y complejidad.",
+            "maridaje": "Carnes rojas, quesos curados, pastas",
+            "card_color": "#8b1a2b"
+          }
+        },
+        "blanco": {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Blanco",
+            "name": "Vino Blanco",
+            "description": "Producido sin contacto con la piel de la uva. Color amarillo palido a dorado, perfil fresco, ligero y acido. Se consume frio.",
+            "maridaje": "Pescados, mariscos, quesos suaves",
+            "card_color": "#c9a96e"
+          }
+        },
+        "rosado": {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Rosado",
+            "name": "Vino Rosado",
+            "description": "Uvas tintas con contacto breve con hollejos. Fresco, ligero y afrutado. Ideal para consumirse joven, servido a 8-12 grados.",
+            "maridaje": "Comida mediterranea, mariscos, ensaladas",
+            "card_color": "#d4729a"
+          }
+        },
+        "espumoso": {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Espumoso",
+            "name": "Espumosos, Cava y Champan",
+            "description": "Vinos con gas carbonico de segunda fermentacion. Burbujas finas y sabores complejos. Incluye Cava espaniol y Champan frances.",
+            "maridaje": "Aperitivos, mariscos, postres",
+            "card_color": "#a68b5b"
+          }
+        },
+        "dulce": {
+          "type": "wine_type",
+          "settings": {
+            "tag": "Dulce",
+            "name": "Blanco Dulce",
+            "description": "Con mas de 45 gramos de azucar por litro. Perfecto para acompaniar postres o disfrutar solo como cierre de una comida especial.",
+            "maridaje": "Postres, foie gras, quesos azules",
+            "card_color": "#d4a843"
+          }
+        }
+      },
+      "block_order": ["tinto", "blanco", "rosado", "espumoso", "dulce"],
+      "settings": {
+        "label": "Nuestra Seleccion",
+        "heading": "Tipos de Vino",
+        "intro": "Cada tipo de vino tiene su propio caracter, historia y momento ideal para disfrutarlo.",
+        "bg_color": "#faf8f5",
+        "accent_color": "#8b1a2b"
+      }
+    },
+    "wine_crianza": {
+      "type": "wine-landing-crianza",
+      "blocks": {
+        "joven": {
+          "type": "level",
+          "settings": {
+            "icon": "grape",
+            "years": "0-12 meses",
+            "name": "Joven",
+            "description": "Vino del anio que destaca por su frescura y frutosidad. Sin paso por barrica."
+          }
+        },
+        "crianza": {
+          "type": "level",
+          "settings": {
+            "icon": "barrel",
+            "years": "24 meses",
+            "name": "Crianza",
+            "description": "Envejecimiento en barrica de roble. El vino evoluciona adquiriendo cualidades positivas y complejidad."
+          }
+        },
+        "reserva": {
+          "type": "level",
+          "settings": {
+            "icon": "bottle",
+            "years": "36 meses",
+            "name": "Reserva",
+            "description": "Minimo 12 meses en barrica de roble. Mayor complejidad, estructura y elegancia."
+          }
+        },
+        "gran_reserva": {
+          "type": "level",
+          "settings": {
+            "icon": "glass",
+            "years": "60 meses",
+            "name": "Gran Reserva",
+            "description": "5 anios de crianza total con 18-24 meses en barrica. Solo de aniadas excelentes."
+          }
+        }
+      },
+      "block_order": ["joven", "crianza", "reserva", "gran_reserva"],
+      "settings": {
+        "label": "Proceso de Envejecimiento",
+        "heading": "Niveles de Crianza",
+        "bg_color": "#1a0a0a",
+        "accent_color": "#c9a96e"
+      }
+    },
+    "wine_products_1": {
+      "type": "carousel-products",
+      "settings": {
+        "title": "Vinos Tintos Destacados",
+        "collection": "vinos-tintos"
+      }
+    },
+    "wine_cta": {
+      "type": "wine-landing-cta",
+      "settings": {
+        "heading": "Encuentra tu vino perfecto",
+        "text": "Explora nuestra seleccion completa y deja que cada copa cuente una historia.",
+        "btn1_text": "Ver Todos los Vinos",
+        "btn2_text": "Ofertas Especiales",
+        "bg_color": "#2d0a1a",
+        "accent_color": "#c9a96e"
+      }
+    },
+    "wine_products_2": {
+      "type": "carousel-products",
+      "settings": {
+        "title": "Vinos Blancos y Rosados",
+        "collection": "vinos-blancos"
+      }
+    },
+    "wine_dictionary": {
+      "type": "wine-landing-dictionary",
+      "blocks": {
+        "t1": { "type": "term", "settings": { "term": "Acerbo", "definition": "Se dice del vino que es a la vez aspero, duro y acido." } },
+        "t2": { "type": "term", "settings": { "term": "Afinado", "definition": "Vino delicado y aromatico que recuerda el sabor y olor del fruto. Caracteristica de vinos jovenes que desaparece con el tiempo." } },
+        "t3": { "type": "term", "settings": { "term": "Amable", "definition": "Vino muy afrutado con buen equilibrio, pudiendo resultar algo abocado y muy agradable en la cata." } },
+        "t4": { "type": "term", "settings": { "term": "Amontillado", "definition": "Vino generoso de color ambar, aroma punzante y avellanado, suave y lleno al paladar, con 18 grados." } },
+        "t5": { "type": "term", "settings": { "term": "Complejo", "definition": "Vino que ofrece una amplia gama de sensaciones, armonia y equilibrio." } },
+        "t6": { "type": "term", "settings": { "term": "Cuerpo", "definition": "Caracteristica ligada al grado alcoholico y extracto seco. Un vino con cuerpo es estructurado." } },
+        "t7": { "type": "term", "settings": { "term": "Equilibrado", "definition": "Vino con conjunto armonioso de caracteres, sin que ninguno sobresalga sobre los demas." } },
+        "t8": { "type": "term", "settings": { "term": "Herbaceo", "definition": "Aroma vegetal provocado por falta de maduracion de las uvas o ruptura del raspon en la prensa." } },
+        "t9": { "type": "term", "settings": { "term": "Hollejo", "definition": "Piel de la uva que contiene taninos. Dan caracter al vino y permiten su conservacion." } },
+        "t10": { "type": "term", "settings": { "term": "Joven", "definition": "Vino del anio que destaca por su frescura y frutosidad." } },
+        "t11": { "type": "term", "settings": { "term": "Mosto", "definition": "Zumo de uva sin fermentar: agua (80%), azucar (17%), vitaminas y minerales." } },
+        "t12": { "type": "term", "settings": { "term": "Seco", "definition": "Vino sin restos de azucar." } },
+        "t13": { "type": "term", "settings": { "term": "Semi seco", "definition": "Vino que contiene de 14 a 30 gramos por litro de azucar." } },
+        "t14": { "type": "term", "settings": { "term": "Tanico", "definition": "Vino que muestra en boca la astringencia de sus taninos." } },
+        "t15": { "type": "term", "settings": { "term": "Varietal", "definition": "Vino elaborado a partir de una unica variedad de uva." } },
+        "t16": { "type": "term", "settings": { "term": "Moscatel", "definition": "Variedad de uva con aromas y sabor muy caracteristicos." } }
+      },
+      "block_order": ["t1","t2","t3","t4","t5","t6","t7","t8","t9","t10","t11","t12","t13","t14","t15","t16"],
+      "settings": {
+        "label": "Aprende Sobre Vinos",
+        "heading": "Diccionario del Vino",
+        "intro": "Domina el vocabulario del vino y sorprende en tu proxima cata.",
+        "show_search": true,
+        "bg_color": "#ffffff",
+        "accent_color": "#8b1a2b"
+      }
+    }
+  },
+  "order": [
+    "wine_hero",
+    "wine_types",
+    "wine_crianza",
+    "wine_products_1",
+    "wine_cta",
+    "wine_products_2",
+    "wine_dictionary"
+  ]
+}


### PR DESCRIPTION
Landing page de vinos con 5 secciones custom + carousel de productos existente.

**Secciones creadas:**
- wine-landing-hero: Banner hero con imagen, badge, titulo, CTA
- wine-landing-types: Grid de tarjetas con tipos de vino (tinto, blanco, rosado, espumoso, dulce)
- wine-landing-crianza: Timeline visual con niveles de crianza (joven, crianza, reserva, gran reserva)
- wine-landing-dictionary: Diccionario del vino con buscador interactivo
- wine-landing-cta: Seccion CTA con botones primario y secundario

**Template:** page.wine-landing.json - incluye 2 carousel-products entre secciones

**Para usar:** Crear una Page en Shopify y asignarle el template 'wine-landing'