### PR TITLE
fix: forzar re-sync template wine-landing

### DIFF
--- a/templates/page.wine-landing.json
+++ b/templates/page.wine-landing.json
@@ -187,5 +187,6 @@
     "wine_cta",
     "wine_products_2",
     "wine_dictionary"
-  ]
+  ],
+  "wrapper": "div"
 }


### PR DESCRIPTION
Fuerza re-sincronizacion del template que Shopify habia rechazado previamente por el error de nombre de seccion.