### PR TITLE
feat: product badges via metaobjeto (bottom-left imagen)

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1640,3 +1640,23 @@ media="(min-width: 1025px)" {
     margin-left: 10px;
   }
 }
+
+/* ========== Product Badges (metaobject) ========== */
+.product-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  position: relative;
+  z-index: 2;
+}
+.product-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  border-radius: 4px;
+  line-height: 1.4;
+  white-space: nowrap;
+}

--- a/snippets/product-badges.liquid
+++ b/snippets/product-badges.liquid
@@ -1,0 +1,22 @@
+{%- comment -%}
+  Renders product badges from metaobject references.
+  Expects: product metafield custom.badges (list of metaobject references)
+  Each metaobject has fields: text (single_line_text), bg_color (single_line_text), text_color (single_line_text)
+  Usage: {% render 'product-badges', product: product %}
+{%- endcomment -%}
+
+{%- assign badges = product.metafields.custom.badges.value -%}
+{%- if badges != blank -%}
+  <div class="product-badges">
+    {%- for badge in badges limit: 2 -%}
+      {%- assign badge_text = badge.text | default: '' -%}
+      {%- assign badge_bg = badge.bg_color | default: '#1a0a0a' -%}
+      {%- assign badge_color = badge.text_color | default: '#ffffff' -%}
+      {%- if badge_text != blank -%}
+        <span class="product-badge" style="background:{{ badge_bg }};color:{{ badge_color }}">
+          {{ badge_text }}
+        </span>
+      {%- endif -%}
+    {%- endfor -%}
+  </div>
+{%- endif -%}

--- a/snippets/product-badges.liquid
+++ b/snippets/product-badges.liquid
@@ -9,9 +9,9 @@
 {%- if badges != blank -%}
   <div class="product-badges">
     {%- for badge in badges limit: 2 -%}
-      {%- assign badge_text = badge.text | default: '' -%}
-      {%- assign badge_bg = badge.bg_color | default: '#1a0a0a' -%}
-      {%- assign badge_color = badge.text_color | default: '#ffffff' -%}
+      {%- assign badge_text = badge.text.value | default: badge.text | default: '' -%}
+      {%- assign badge_bg = badge.bg_color.value | default: badge.bg_color | default: '#1a0a0a' -%}
+      {%- assign badge_color = badge.text_color.value | default: badge.text_color | default: '#ffffff' -%}
       {%- if badge_text != blank -%}
         <span class="product-badge" style="background:{{ badge_bg }};color:{{ badge_color }}">
           {{ badge_text }}
@@ -19,4 +19,7 @@
       {%- endif -%}
     {%- endfor -%}
   </div>
+{%- endif -%}
+{%- if request.design_mode -%}
+  <div style="font-size:10px;color:#999;margin-top:2px">[badges: {{ product.metafields.custom.badges | size }}]</div>
 {%- endif -%}

--- a/snippets/product-collection.liquid
+++ b/snippets/product-collection.liquid
@@ -133,6 +133,9 @@
                         {%- endif -%}
                     </div>
                 {%- endif -%}
+                <div class="product-image__overlay-badges position-absolute d-flex align-items-end bottom-0 left-0 px-10 pb-10" style="pointer-events:none">
+                    {% render 'product-badges', product: product %}
+                </div>
             </div>
             <div class="product-collection__content d-flex flex-column align-items-start mt-15">
                 {%- case settings.product_collection_more_info_type -%}


### PR DESCRIPTION
Agrega badges de producto configurables via metaobjeto. Soporta hasta 2 badges con texto, color de fondo y color de texto custom. Se muestran flotando en la esquina inferior izquierda de la imagen del producto.