### PR TITLE
feat: barrios por sede + filtrado de inventario por Location

### DIFF
--- a/assets/store-selector.css
+++ b/assets/store-selector.css
@@ -809,3 +809,121 @@
     height: 36px;
   }
 }
+
+/* ========== SELECTOR DE BARRIO ========== */
+.walmart-barrio-section {
+  margin: 16px 0;
+  position: relative;
+}
+
+.walmart-barrio-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--walmart-dark);
+  margin-bottom: 8px;
+}
+
+.walmart-barrio-search-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--walmart-border);
+  border-radius: 24px;
+  padding: 10px 16px;
+  background: #fff;
+  transition: border-color 0.2s ease;
+}
+
+.walmart-barrio-search-wrapper:focus-within {
+  border-color: var(--walmart-blue);
+}
+
+.walmart-barrio-input {
+  border: none;
+  outline: none;
+  flex: 1;
+  font-size: 15px;
+  color: var(--walmart-dark);
+  background: transparent;
+}
+
+.walmart-barrio-results {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 4px;
+  border: 1px solid var(--walmart-border);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+  max-height: 260px;
+  overflow-y: auto;
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: none;
+}
+
+.walmart-barrio-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.walmart-barrio-item:hover {
+  background: #fff0f0;
+}
+
+.walmart-barrio-item-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--walmart-dark);
+}
+
+.walmart-barrio-item-store {
+  font-size: 12px;
+  color: var(--walmart-gray);
+}
+
+.walmart-barrio-empty {
+  padding: 12px;
+  text-align: center;
+  color: var(--walmart-gray);
+  font-size: 13px;
+}
+
+/* ========== PRODUCTO NO DISPONIBLE EN LA TIENDA ELEGIDA ========== */
+product-item.is-unavailable-at-store {
+  position: relative;
+  opacity: 0.55;
+  filter: grayscale(0.6);
+}
+
+product-item.is-unavailable-at-store::after {
+  content: "No disponible en tu tienda";
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(4, 30, 66, 0.9);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 12px;
+  z-index: 5;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+product-item.is-unavailable-at-store .product-collection__button-add-to-cart,
+product-item.is-unavailable-at-store [data-js-product-add-to-cart],
+product-item.is-unavailable-at-store .btn-add-to-cart {
+  pointer-events: none;
+  opacity: 0.5;
+}

--- a/assets/store-selector.js
+++ b/assets/store-selector.js
@@ -8,6 +8,8 @@ class WalmartStoreSelector {
     this.STORAGE_KEY = 'walmart_selected_store';
     this.DELIVERY_MODE_KEY = 'walmart_delivery_mode';
     this.DROPDOWN_CLOSED_KEY = 'walmart_dropdown_closed';
+    this.BARRIO_KEY = 'walmart_selected_barrio';
+    this.LOCATION_KEY = 'walmart_selected_location';
     this.COOKIE_EXPIRY_DAYS = 30; // Cookie expira en 30 días
     
     // Elementos del DOM
@@ -21,6 +23,9 @@ class WalmartStoreSelector {
     this.selectedStore = null;
     this.deliveryMode = 'retiro'; // envio, retiro, entrega
     this.userLocation = null;
+    this.barrioIndex = []; // [{ barrio, store }]
+    this.selectedBarrio = null;
+    this.selectedLocationId = null;
     
     this.init();
   }
@@ -28,6 +33,9 @@ class WalmartStoreSelector {
   async init() {
     // Cargar tiendas
     await this.loadStores();
+
+    // Construir índice de barrios
+    this.buildBarrioIndex();
     
     // Cargar datos guardados
     this.loadSavedData();
@@ -37,6 +45,10 @@ class WalmartStoreSelector {
     
     // Eventos
     this.attachEventListeners();
+
+    // Aplicar filtro de inventario por location (Fase 2)
+    this.applyLocationFilter();
+    this.observeProductGrid();
     
     // Si no hay tienda seleccionada Y el usuario no ha cerrado el dropdown manualmente, mostrar después de 1.5 seg
     const dropdownClosedByUser = this.getCookie(this.DROPDOWN_CLOSED_KEY);
@@ -45,6 +57,17 @@ class WalmartStoreSelector {
         this.showDropdown();
       }, 1500);
     }
+  }
+
+  buildBarrioIndex() {
+    this.barrioIndex = [];
+    this.stores.forEach(store => {
+      (store.barrios || []).forEach(barrio => {
+        if (barrio) {
+          this.barrioIndex.push({ barrio: barrio, store: store });
+        }
+      });
+    });
   }
 
   async loadStores() {
@@ -63,6 +86,10 @@ class WalmartStoreSelector {
       
       this.stores = Array.from(storeCards).map((card, index) => {
         const logo = card.querySelector('.header-logo-card img');
+        const barrios = (card.dataset.barrios || '')
+          .split(/[\n,]+/)
+          .map(b => b.trim())
+          .filter(Boolean);
         return {
           id: index.toString(),
           name: card.querySelector('.store-card__name')?.textContent.trim() || '',
@@ -72,6 +99,8 @@ class WalmartStoreSelector {
           latitude: parseFloat(card.dataset.lat) || 0,
           longitude: parseFloat(card.dataset.lng) || 0,
           logo: logo ? logo.src : '',
+          locationId: (card.dataset.locationId || '').trim(),
+          barrios: barrios,
           featured: card.classList.contains('store-card--featured')
         };
       }).filter(store => store.name && store.latitude && store.longitude);
@@ -91,6 +120,8 @@ class WalmartStoreSelector {
     try {
       const savedStore = localStorage.getItem(this.STORAGE_KEY);
       const savedMode = localStorage.getItem(this.DELIVERY_MODE_KEY);
+      const savedBarrio = localStorage.getItem(this.BARRIO_KEY);
+      const savedLocation = localStorage.getItem(this.LOCATION_KEY);
       
       if (savedStore) {
         this.selectedStore = JSON.parse(savedStore);
@@ -98,6 +129,14 @@ class WalmartStoreSelector {
       
       if (savedMode) {
         this.deliveryMode = savedMode;
+      }
+
+      if (savedBarrio) {
+        this.selectedBarrio = savedBarrio;
+      }
+
+      if (savedLocation) {
+        this.selectedLocationId = savedLocation;
       }
     } catch (e) {
       console.error('Error cargando datos guardados:', e);
@@ -110,6 +149,13 @@ class WalmartStoreSelector {
         localStorage.setItem(this.STORAGE_KEY, JSON.stringify(this.selectedStore));
       }
       localStorage.setItem(this.DELIVERY_MODE_KEY, this.deliveryMode);
+
+      if (this.selectedBarrio) {
+        localStorage.setItem(this.BARRIO_KEY, this.selectedBarrio);
+      }
+      if (this.selectedLocationId) {
+        localStorage.setItem(this.LOCATION_KEY, this.selectedLocationId);
+      }
     } catch (e) {
       console.error('Error guardando datos:', e);
     }
@@ -119,6 +165,13 @@ class WalmartStoreSelector {
     // Botón del header
     if (this.headerBtn) {
       this.headerBtn.addEventListener('click', () => this.toggleDropdown());
+    }
+
+    // Búsqueda de barrio
+    const barrioInput = document.getElementById('walmart-barrio-input');
+    if (barrioInput) {
+      barrioInput.addEventListener('input', (e) => this.renderBarrioResults(e.target.value));
+      barrioInput.addEventListener('focus', (e) => this.renderBarrioResults(e.target.value));
     }
 
     // Cerrar dropdown
@@ -314,11 +367,115 @@ class WalmartStoreSelector {
     const textEl = document.getElementById('walmart-header-store-text');
     if (!textEl) return;
 
-    if (this.selectedStore) {
+    if (this.selectedBarrio && this.selectedStore) {
+      textEl.textContent = `${this.selectedBarrio} • ${this.selectedStore.name}`;
+    } else if (this.selectedStore) {
       textEl.textContent = `${this.selectedStore.name} • ${this.selectedStore.zone || ''}`;
     } else {
       textEl.textContent = 'Selecciona una tienda';
     }
+  }
+
+  // ===== BARRIOS =====
+  renderBarrioResults(term) {
+    const list = document.getElementById('walmart-barrio-results');
+    if (!list) return;
+
+    const q = (term || '').toLowerCase().trim();
+    let matches = this.barrioIndex;
+    if (q) {
+      matches = this.barrioIndex.filter(item => item.barrio.toLowerCase().includes(q));
+    }
+    matches = matches.slice(0, 8);
+
+    if (matches.length === 0) {
+      list.innerHTML = this.barrioIndex.length === 0
+        ? '<li class="walmart-barrio-empty">No hay barrios configurados</li>'
+        : '<li class="walmart-barrio-empty">Sin coincidencias</li>';
+      list.style.display = 'block';
+      return;
+    }
+
+    list.innerHTML = matches.map(item => `
+      <li class="walmart-barrio-item" role="option"
+          data-barrio="${item.barrio.replace(/"/g, '&quot;')}"
+          data-store-id="${item.store.id}">
+        <span class="walmart-barrio-item-name">${item.barrio}</span>
+        <span class="walmart-barrio-item-store">${item.store.name}</span>
+      </li>
+    `).join('');
+    list.style.display = 'block';
+
+    list.querySelectorAll('.walmart-barrio-item').forEach(el => {
+      el.addEventListener('click', () => {
+        this.selectBarrio(el.dataset.barrio, el.dataset.storeId);
+      });
+    });
+  }
+
+  selectBarrio(barrio, storeId) {
+    const store = this.stores.find(s => s.id === storeId);
+    if (!store) return;
+
+    this.selectedBarrio = barrio;
+    this.selectedStore = store;
+    this.selectedLocationId = store.locationId || '';
+    this.saveData();
+
+    // UI
+    const input = document.getElementById('walmart-barrio-input');
+    if (input) input.value = barrio;
+    const list = document.getElementById('walmart-barrio-results');
+    if (list) list.style.display = 'none';
+
+    this.updateHeaderButton();
+    this.showSuggestedStore(store);
+    this.applyLocationFilter();
+    this.hideDropdown();
+
+    window.dispatchEvent(new CustomEvent('storeSelected', {
+      detail: { store: store, barrio: barrio, locationId: this.selectedLocationId }
+    }));
+  }
+
+  // ===== FILTRO DE INVENTARIO POR LOCATION (Fase 2) =====
+  applyLocationFilter() {
+    const locId = this.selectedLocationId;
+    const items = document.querySelectorAll('product-item[data-available-locations], [data-available-locations].product-collection');
+
+    items.forEach(item => {
+      // Sin location seleccionada: mostrar todo
+      if (!locId) {
+        item.classList.remove('is-unavailable-at-store');
+        return;
+      }
+      const raw = item.getAttribute('data-available-locations') || '';
+      const locs = raw.split(',').map(s => s.trim()).filter(Boolean);
+      // Si el producto no declara locations, no lo filtramos (fallback seguro)
+      if (locs.length === 0) {
+        item.classList.remove('is-unavailable-at-store');
+        return;
+      }
+      if (locs.indexOf(locId) === -1) {
+        item.classList.add('is-unavailable-at-store');
+      } else {
+        item.classList.remove('is-unavailable-at-store');
+      }
+    });
+  }
+
+  observeProductGrid() {
+    // Re-aplicar el filtro cuando se cargan productos por AJAX (filtros, paginación infinita)
+    let scheduled = false;
+    const observer = new MutationObserver(() => {
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(() => {
+        scheduled = false;
+        this.applyLocationFilter();
+      });
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
   }
 
   showSuggestedStore(store) {

--- a/sections/store-directory.liquid
+++ b/sections/store-directory.liquid
@@ -159,6 +159,8 @@
                          data-zone="{{ block.settings.zone }}" 
                          data-lat="{{ block.settings.latitude }}" 
                          data-lng="{{ block.settings.longitude }}"
+                         data-location-id="{{ block.settings.location_id }}"
+                         data-barrios="{{ block.settings.barrios | escape }}"
                          {{ block.shopify_attributes }}>
                         <div class="store-card__header">
                             <div class="header-logo-card">
@@ -239,6 +241,18 @@
           "type": "image_picker",
           "id": "logo",
           "label": "Logo de la tienda"
+        },
+        {
+          "type": "text",
+          "id": "location_id",
+          "label": "ID de Location (Shopify)",
+          "info": "ID numérico de la Location de Shopify asignada a esta tienda. Settings > Locations > (abrir location) > el número al final de la URL."
+        },
+        {
+          "type": "textarea",
+          "id": "barrios",
+          "label": "Barrios / Áreas de cobertura",
+          "info": "Un barrio por línea o separados por coma. Al elegir uno se carga el inventario de la Location de esta tienda."
         },
         {
           "type": "text",

--- a/snippets/product-collection.liquid
+++ b/snippets/product-collection.liquid
@@ -60,8 +60,20 @@
 {%- assign img_hover_url = hover_image | img_url: '1x1', format: image_format | replace: '_1x1.', '_{width}x.' -%}
 {%- assign product_form_id = 'quick-add-' | append: section.id | append: product.id -%}
 
+{%- comment -%} Inventario por Location: lista de sedes donde el producto está disponible (Recogida local) {%- endcomment -%}
+{%- assign available_locations = '' -%}
+{%- for variant in product.variants -%}
+    {%- for availability in variant.store_availabilities -%}
+        {%- if availability.available -%}
+            {%- assign loc_token = ',' | append: availability.location.id | append: ',' -%}
+            {%- unless available_locations contains loc_token -%}
+                {%- assign available_locations = available_locations | append: availability.location.id | append: ',' -%}
+            {%- endunless -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
 
-<product-item class="product-collection{% if settings.product_collection_centered_info %} product-collection--centered{% endif %} d-block"{% include 'product-get-attributes' %} data-qv-check-change>
+<product-item class="product-collection{% if settings.product_collection_centered_info %} product-collection--centered{% endif %} d-block"{% include 'product-get-attributes' %} data-available-locations="{{ available_locations }}" data-qv-check-change>
     <div class="product-collection__wrapper">
         <div class="d-flex flex-column">
             <div class="product-collection__image product-image product-image--hover-{{ settings.product_hover_animation_type }} position-relative w-100 js-product-images-navigation js-product-images-hovered-end{% if settings.product_replace_images_hover %} js-product-images-hover{% endif %}"{% if settings.product_replace_images_hover and hover_image != blank %} data-js-product-image-hover="{{ img_hover_url }}" data-js-product-image-hover-id="{{ hover_image.id }}"{% endif %}>

--- a/snippets/store-selector.liquid
+++ b/snippets/store-selector.liquid
@@ -65,6 +65,25 @@
       </div>
     </div>
 
+    <!-- Selector de barrio -->
+    <div class="walmart-barrio-section">
+      <label class="walmart-barrio-label">Selecciona tu barrio</label>
+      <div class="walmart-barrio-search-wrapper">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#666" stroke-width="2">
+          <circle cx="11" cy="11" r="8"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+        <input
+          type="text"
+          id="walmart-barrio-input"
+          placeholder="Escribe tu barrio..."
+          class="walmart-barrio-input"
+          autocomplete="off"
+        >
+      </div>
+      <ul id="walmart-barrio-results" class="walmart-barrio-results" role="listbox"></ul>
+    </div>
+
     <!-- Campo de dirección -->
     <div class="walmart-address-section">
       <div class="walmart-address-icon">


### PR DESCRIPTION
## Qué hace

Fase 1 + 2 del selector de tienda por barrio.

### Fase 1 - Barrios -> Location
- Nuevos campos en la seccion `Directorio de Tiendas` por tienda: **ID de Location (Shopify)** y **Barrios / Áreas de cobertura** (uno por linea o separados por coma).
- El selector muestra un buscador de barrio; al elegir uno se resuelve la tienda/Location, se guarda en localStorage y se dispara el evento `storeSelected` con `locationId`.
- El boton del header muestra el barrio elegido.

### Fase 2 - Filtrado de inventario por sede
- `product-collection.liquid` expone `data-available-locations` derivado de `variant.store_availabilities` (Recogida local nativa, auto-sincronizada con el stock real).
- El JS oculta/opaca los productos no disponibles en la Location del barrio elegido (clase `is-unavailable-at-store`) y re-aplica el filtro ante cambios del grid (AJAX/paginacion).

## Config requerida en Shopify
1. Activar **Recogida local** en cada Location.
2. En cada tienda del directorio, rellenar **ID de Location** y **Barrios**.

Solo a staging.